### PR TITLE
LunrBaseTestCase: Remove deprecated methods

### DIFF
--- a/src/Lunr/Halo/LunrBaseTestCase.php
+++ b/src/Lunr/Halo/LunrBaseTestCase.php
@@ -128,20 +128,6 @@ abstract class LunrBaseTestCase extends TestCase
     }
 
     /**
-     * Get an accessible ReflectionMethod.
-     *
-     * @param string $method Method name
-     *
-     * @deprecated Use get_reflection_method() instead
-     *
-     * @return ReflectionMethod The ReflectionMethod instance
-     */
-    protected function get_accessible_reflection_method(string $method): ReflectionMethod
-    {
-        return $this->get_reflection_method($method);
-    }
-
-    /**
      * Get a ReflectionMethod.
      *
      * @param string $method Method name
@@ -165,20 +151,6 @@ abstract class LunrBaseTestCase extends TestCase
     {
         $this->get_reflection_property($property)
              ->setValue($this->class, $value);
-    }
-
-    /**
-     * Get an accessible ReflectionProperty.
-     *
-     * @param string $property Property name
-     *
-     * @deprecated Use get_reflection_property() instead
-     *
-     * @return ReflectionProperty The ReflectionProperty instance
-     */
-    protected function get_accessible_reflection_property(string $property): ReflectionProperty
-    {
-        return $this->get_reflection_property($property);
     }
 
     /**

--- a/src/Lunr/Halo/Tests/LunrBaseTestCaseReflectionTest.php
+++ b/src/Lunr/Halo/Tests/LunrBaseTestCaseReflectionTest.php
@@ -22,19 +22,6 @@ class LunrBaseTestCaseReflectionTest extends LunrBaseTestCaseTestCase
 {
 
     /**
-     * Test get_accessible_reflection_method()
-     *
-     * @covers Lunr\Halo\LunrBaseTestCase::get_accessible_reflection_method
-     */
-    public function testGetAccessibleReflectionMethod(): void
-    {
-        $method = $this->get_accessible_reflection_method('baz');
-
-        $this->assertInstanceOf(ReflectionMethod::class, $method);
-        $this->assertEquals('baz', $method->name);
-    }
-
-    /**
      * Test get_reflection_method()
      *
      * @covers Lunr\Halo\LunrBaseTestCase::get_reflection_method
@@ -45,19 +32,6 @@ class LunrBaseTestCaseReflectionTest extends LunrBaseTestCaseTestCase
 
         $this->assertInstanceOf(ReflectionMethod::class, $method);
         $this->assertEquals('baz', $method->name);
-    }
-
-    /**
-     * Test get_accessible_reflection_property()
-     *
-     * @covers Lunr\Halo\LunrBaseTestCase::get_accessible_reflection_property
-     */
-    public function testGetAccessibleReflectionProperty(): void
-    {
-        $property = $this->get_accessible_reflection_property('foo');
-
-        $this->assertInstanceOf(ReflectionProperty::class, $property);
-        $this->assertEquals('foo', $property->name);
     }
 
     /**


### PR DESCRIPTION
- get_accessible_reflection_method()
- get_accessible_reflection_property()