### PR TITLE
CI: Fix phpstan analysis with decomposer

### DIFF
--- a/decomposer.json
+++ b/decomposer.json
@@ -18,9 +18,8 @@
     "PHPUnit": {
         "url": "https://github.com/sebastianbergmann/phpunit.git",
         "version": "10.5.38",
-        "psr4": {
-            "prefix": "PHPUnit",
-            "search-path": "/src/"
+        "psr0": {
+            "path": "/src/"
         }
     }
 }

--- a/tests/phpstan.autoload.inc.php
+++ b/tests/phpstan.autoload.inc.php
@@ -18,11 +18,22 @@ if (file_exists($base . '/vendor/autoload.php') == TRUE)
 }
 else
 {
-    // Load decomposer autoloade.
+    // Load decomposer autoloader.
     $autoload_file = $base . '/decomposer.autoload.inc.php';
 }
 
 require_once $autoload_file;
+
+if (file_exists($base . '/vendor/autoload.php') == FALSE)
+{
+    include_once 'Framework/MockObject/Runtime/Interface/Stub.php';
+    include_once 'Framework/MockObject/Runtime/Interface/MockObject.php';
+    include_once 'Framework/Assert.php';
+    include_once 'Framework/Reorderable.php';
+    include_once 'Framework/SelfDescribing.php';
+    include_once 'Framework/Test.php';
+    include_once 'Framework/TestCase.php';
+}
 
 // Define application config lookup path
 $paths = [


### PR DESCRIPTION
PHPUnit doesn't use PSR-0 or PSR-4, but a classmap autoloader, and decomposer doesn't support those. Therefore we have to load the dependencies manually when using decomposer :(

We switch from psr4 to psr0 for decomposer, since psr0 sets up the include path we need for the manual includes. The includes themselves are version specific to PHPUnit, so they would be different for PHPUnit 9, hence not targetting the release branch.